### PR TITLE
Wrong variable in some IF statements

### DIFF
--- a/CloudKey.php
+++ b/CloudKey.php
@@ -337,7 +337,7 @@ class CloudKey_Api
             }
             if ($seclevel & CLOUDKEY_SECLEVEL_IP)
             {
-                if (!isset($asnum))
+                if (!isset($ip))
                 {
                     throw new InvalidArgumentException('IP security level required and no IP address provided.');
                 }
@@ -345,7 +345,7 @@ class CloudKey_Api
             }
             if ($seclevel & CLOUDKEY_SECLEVEL_USERAGENT)
             {
-                if (!isset($asnum))
+                if (!isset($useragent))
                 {
                     throw new InvalidArgumentException('USERAGENT security level required and no user-agent provided.');
                 }


### PR DESCRIPTION
Bonjour,

Il semble que le patch que je vous ai soumis n'ai pas été totalement pris en compte.
En effet il ne corrigeait pas seulement une erreur de typographie dû au portage de Python vers PHP mais aussi des noms de variables incorrect dans certaines conditions.

Cordialement.
