### PR TITLE
TKT1 - fix curl on php 5.5.9+ versions

### DIFF
--- a/CloudKey.php
+++ b/CloudKey.php
@@ -163,7 +163,7 @@ class CloudKey_File extends CloudKey_Api
             CURLOPT_FOLLOWLOCATION => true,
             CURLOPT_CONNECTTIMEOUT => 30,
             CURLOPT_POST => true,
-            CURLOPT_POSTFIELDS => array('file' => '@' . $file),
+            CURLOPT_POSTFIELDS => array('file' => new \CURLFile($file)),
         ));
 
         if ($this->proxy !== null)


### PR DESCRIPTION
On newer versions of PHP we get a curl error as the '@'  descriptor is deprecated.
